### PR TITLE
add engraver to all voice types

### DIFF
--- a/frames/module.ily
+++ b/frames/module.ily
@@ -1658,4 +1658,28 @@ colorFrame = #(define-music-function (y-lower y-upper border-color)
     \Voice
     \consists "Horizontal_bracket_engraver"
   }
+  \context {
+    \DrumVoice
+    \consists "Horizontal_bracket_engraver"
+  }
+  \context {
+    \GregorianTranscriptionVoice
+    \consists "Horizontal_bracket_engraver"
+  }
+  \context {
+    \KievanVoice
+    \consists "Horizontal_bracket_engraver"
+  }
+  \context {
+    \MensuralVoice
+    \consists "Horizontal_bracket_engraver"
+  }
+  \context {
+    \PetrucciVoice
+    \consists "Horizontal_bracket_engraver"
+  }
+  \context {
+    \VaticanaVoice
+    \consists "Horizontal_bracket_engraver"
+  }
 }


### PR DESCRIPTION
Make Horizontal_bracket_engraver available in all voice types, e.g. DrumVoice etc.